### PR TITLE
Update SC Cache Cleaner 317.bat

### DIFF
--- a/SC Cache Cleaner 317.bat
+++ b/SC Cache Cleaner 317.bat
@@ -95,7 +95,7 @@ IF EXIST "%GameBase%\PTU\USER\Client\0\DebugGUI\" (
 del "%GameBase%\PTU\USER\Client\0\*.cfg" 2>&1 1>nul | findstr "^" > nul && echo PTU - [93mNo cfg files to clean yet![0m || echo PTU - Cleaning old cfg files: [92mSUCCESS![0m
 
 ::Remove Cache folder in 3.17 Local App Data Directory
-cd "%localappdata%\Star Citizen"
+cd /D "%localappdata%\Star Citizen"
 IF EXIST "%cd%\sc-alpha*" (
 	(for /d %%G in ("%cd%\sc-alpha*") do rd /s /q "%%~G") && ECHO ALL - Clearing AppLocal Shaders Cache: [92mSUCCESS![0m
 ) else (


### PR DESCRIPTION
Ignore the parenthesis comment in your email if you read that, i found out after a second run why you had those around your "for" loop.

However retaining the addition of "/D" to the cd before your for loop. script erroneously skips over appdata cleanup if game client is on a different drive from C:. Added "/D" to include a drive jump if needed.